### PR TITLE
pinning alarms

### DIFF
--- a/src/monitoring.tf
+++ b/src/monitoring.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "database_capacity_alarm" {
-  source = "../../../provisioners/terraform/modules/aws-cloudwatch-alarm"
+  source = "github.com/massdriver-cloud/terraform-modules//aws-cloudwatch-alarm?ref=54da4ef"
 
   depends_on = [
     aws_rds_cluster.main


### PR DESCRIPTION
pinning alarms to prep for backward incompat change to main on terraform-modules